### PR TITLE
Immune from dependency inclusion issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,13 @@
                     <lambdaMaximumExecutionTime>${deployment.maximumExecutionTime}</lambdaMaximumExecutionTime>
                     <lambdaMemorySize>${deployment.lambdaMemorySize}</lambdaMemorySize>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.lambadaframework</groupId>
+                        <artifactId>boilerplate</artifactId>
+                        <version>0.0.6</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
See discussion regarding issue:
https://github.com/lambadaframework/lambadaframework/issues/30

This is a work around. The maven plugin will probably need to be configured to do some unpacking of the shaded jar. (Assumption, not sure.)
